### PR TITLE
Optimize CoveredImage render path

### DIFF
--- a/application/client/src/components/foundation/CoveredImage.tsx
+++ b/application/client/src/components/foundation/CoveredImage.tsx
@@ -1,15 +1,23 @@
-import classNames from "classnames";
-import sizeOf from "image-size";
 import { load, ImageIFD } from "piexifjs";
-import { MouseEvent, RefCallback, useCallback, useId, useMemo, useState } from "react";
+import { MouseEvent, useCallback, useId, useState } from "react";
 
 import { Button } from "@web-speed-hackathon-2026/client/src/components/foundation/Button";
 import { Modal } from "@web-speed-hackathon-2026/client/src/components/modal/Modal";
-import { useFetch } from "@web-speed-hackathon-2026/client/src/hooks/use_fetch";
-import { fetchBinary } from "@web-speed-hackathon-2026/client/src/utils/fetchers";
 
 interface Props {
   src: string;
+}
+
+async function loadImageDescription(src: string): Promise<string> {
+  const res = await fetch(src);
+  if (!res.ok) {
+    return "";
+  }
+
+  const data = await res.arrayBuffer();
+  const exif = load(Buffer.from(data).toString("binary"));
+  const raw = exif?.["0th"]?.[ImageIFD.ImageDescription];
+  return raw != null ? new TextDecoder().decode(Buffer.from(raw, "binary")) : "";
 }
 
 /**
@@ -17,54 +25,34 @@ interface Props {
  */
 export const CoveredImage = ({ src }: Props) => {
   const dialogId = useId();
+  const [alt, setAlt] = useState<string | null>(null);
+  const [isLoadingAlt, setIsLoadingAlt] = useState(false);
+
   // ダイアログの背景をクリックしたときに投稿詳細ページに遷移しないようにする
   const handleDialogClick = useCallback((ev: MouseEvent<HTMLDialogElement>) => {
     ev.stopPropagation();
   }, []);
 
-  const { data, isLoading } = useFetch(src, fetchBinary);
+  const handleOpenAlt = useCallback(() => {
+    if (alt !== null || isLoadingAlt) {
+      return;
+    }
 
-  const imageSize = useMemo(() => {
-    return data != null ? sizeOf(Buffer.from(data)) : { height: 0, width: 0 };
-  }, [data]);
-
-  const alt = useMemo(() => {
-    const exif = data != null ? load(Buffer.from(data).toString("binary")) : null;
-    const raw = exif?.["0th"]?.[ImageIFD.ImageDescription];
-    return raw != null ? new TextDecoder().decode(Buffer.from(raw, "binary")) : "";
-  }, [data]);
-
-  const blobUrl = useMemo(() => {
-    return data != null ? URL.createObjectURL(new Blob([data])) : null;
-  }, [data]);
-
-  const [containerSize, setContainerSize] = useState({ height: 0, width: 0 });
-  const callbackRef = useCallback<RefCallback<HTMLDivElement>>((el) => {
-    setContainerSize({
-      height: el?.clientHeight ?? 0,
-      width: el?.clientWidth ?? 0,
-    });
-  }, []);
-
-  if (isLoading || data === null || blobUrl === null) {
-    return null;
-  }
-
-  const containerRatio = containerSize.height / containerSize.width;
-  const imageRatio = imageSize?.height / imageSize?.width;
+    setIsLoadingAlt(true);
+    void loadImageDescription(src)
+      .then(setAlt)
+      .catch(() => setAlt(""))
+      .finally(() => setIsLoadingAlt(false));
+  }, [alt, isLoadingAlt, src]);
 
   return (
-    <div ref={callbackRef} className="relative h-full w-full overflow-hidden">
+    <div className="relative h-full w-full overflow-hidden">
       <img
-        alt={alt}
-        className={classNames(
-          "absolute left-1/2 top-1/2 max-w-none -translate-x-1/2 -translate-y-1/2",
-          {
-            "w-auto h-full": containerRatio > imageRatio,
-            "w-full h-auto": containerRatio <= imageRatio,
-          },
-        )}
-        src={blobUrl}
+        alt={alt ?? ""}
+        className="h-full w-full"
+        decoding="async"
+        src={src}
+        style={{ inset: 0, objectFit: "cover", position: "absolute" }}
       />
 
       <button
@@ -72,6 +60,7 @@ export const CoveredImage = ({ src }: Props) => {
         type="button"
         command="show-modal"
         commandfor={dialogId}
+        onClick={handleOpenAlt}
       >
         ALT を表示する
       </button>
@@ -80,7 +69,9 @@ export const CoveredImage = ({ src }: Props) => {
         <div className="grid gap-y-6">
           <h1 className="text-center text-2xl font-bold">画像の説明</h1>
 
-          <p className="text-sm">{alt}</p>
+          <p className="text-sm">
+            {isLoadingAlt ? "読み込み中..." : (alt ?? "") || "画像の説明はありません"}
+          </p>
 
           <Button variant="secondary" command="close" commandfor={dialogId}>
             閉じる


### PR DESCRIPTION
This pull request refactors the `CoveredImage` component to simplify its logic and improve how it loads and displays image descriptions (ALT text). The main changes involve removing unnecessary dependencies and optimizing how the component fetches and displays EXIF image descriptions on demand.

**Refactoring and simplification:**

* Removed the use of `useFetch`, `fetchBinary`, `sizeOf`, and `classnames`, as well as all logic related to calculating image size and aspect ratio. The image is now always rendered with `object-fit: cover` using the native `img` tag and CSS.
* The EXIF image description (ALT text) is now loaded only when the user clicks the "ALT を表示する" button, using a new `loadImageDescription` async function. This reduces unnecessary data fetching and processing.
* The component now manages its own loading state (`isLoadingAlt`) for the ALT text, displaying "読み込み中..." while loading and a fallback message if no description is found.

**User experience improvements:**

* The ALT text dialog now provides clearer feedback: it shows a loading message while fetching, and a friendly message if no description is available.
* The image rendering is more robust and efficient, with simplified styling and no dependency on container size or aspect ratio calculations.